### PR TITLE
Fix create timeout of aws_route to 10min

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ resource "aws_route" "public_internet_gateway" {
   gateway_id             = aws_internet_gateway.this[0].id
 
   timeouts {
-    create = "5m"
+    create = "10m"
   }
 }
 


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-5979
```
2020-05-14T00:23:30.8335285Z TestEndToEnd 2020-05-14T00:23:30Z command.go:121: Error: Unable to find matching route for Route Table (rtb-0d5cc8cacd6039bb8) and destination CIDR block (0.0.0.0/0).
2020-05-14T00:23:30.8335966Z TestEndToEnd 2020-05-14T00:23:30Z command.go:121: 
2020-05-14T00:23:30.8337158Z TestEndToEnd 2020-05-14T00:23:30Z command.go:121:   on .terraform/modules/network.vpc/terraform-aws-vpc-2.33.0/main.tf line 128, in resource "aws_route" "public_internet_gateway":
2020-05-14T00:23:30.8337888Z TestEndToEnd 2020-05-14T00:23:30Z command.go:121:  128: resource "aws_route" "public_internet_gateway" {
2020-05-14T00:23:30.8338766Z TestEndToEnd 2020-05-14T00:23:30Z command.go:121: 
2020-05-14T00:23:30.8339322Z TestEndToEnd 2020-05-14T00:23:30Z command.go:121: 
2020-05-14T00:23:30.8401934Z TestEndToEnd 2020-05-14T00:23:30Z retry.go:77: Returning due to fatal error: FatalError{Underlying: exit status 1}
```

# Done
Fix timeout to 10min.

# Refs
https://github.com/terraform-providers/terraform-provider-aws/issues/13138